### PR TITLE
Added selectSameOptionMultipleTimes for multi select situation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ onRemove(selectedList, removedItem) {
 | `closeOnSelect` | `bool` | `true` | Dropdown get closed on select item.
 | `id` | `string` | `''` | Id for the input field.
 | `avoidHighlightFirstOption` | `bool` | `false` | Based on flag first option will get highlight whenever optionlist open.
+| `selectSameOptionMultipleTimes` | `bool` | `false` | To select the same item multiple times 
+
 
 ----
 

--- a/src/multiselect/multiselect.component.js
+++ b/src/multiselect/multiselect.component.js
@@ -249,9 +249,11 @@ export class Multiselect extends React.Component {
       onSelect([item], item);
       return;
     }
-    if (this.isSelectedValue(item)) {
-      this.onRemoveSelectedItem(item);
-      return;
+    if(!selectSameOptionMultipleTimes){
+    	if (this.isSelectedValue(item)) {
+      		this.onRemoveSelectedItem(item);
+      	return;
+    	}
     }
     if (selectionLimit == selectedValues.length) {
       return;
@@ -473,5 +475,6 @@ Multiselect.defaultProps = {
   caseSensitiveSearch: false,
   id: '',
   closeOnSelect: true,
-  avoidHighlightFirstOption: false
+  avoidHighlightFirstOption: false,
+  selectSameOptionMultipleTimes:false
 };


### PR DESCRIPTION
Added selectSameOptionMultipleTimes for multi select situation.
Multi select situation usually happens when
Senario1: You have two people in the class have the same name, and you do want to list their name as what they are.
Senario2: If you want to make a calculation and do 1+1, you will need to enter 1 twice.
Senario3: You want to list all the exam scores you have in a semester for calculation and you have 3 exams that have the exact same score.