### PR TITLE
Update multiselect.component.js

### DIFF
--- a/src/multiselect/multiselect.component.js
+++ b/src/multiselect/multiselect.component.js
@@ -300,8 +300,8 @@ export class Multiselect extends React.Component {
     const { groupedObject } = this.state;
     return Object.keys(groupedObject).map(obj => {
 			return (
-				<React.Fragment>
-					<li key={obj} className={ms.groupHeading} style={style['groupHeading']}>{obj}</li>
+				<React.Fragment key={obj}>
+					<li className={ms.groupHeading} style={style['groupHeading']}>{obj}</li>
 					{groupedObject[obj].map((option, i) => (
 						<li
 							key={`option${i}`}


### PR DESCRIPTION
Moved key to be in React.Fragment instead of \<li\> when using the groupBy option.

This removes the warning for listed components needing a key.

https://github.com/srigar/multiselect-react-dropdown/issues/30