### PR TITLE
Added keepSearchTerm prop to retain search value

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ onRemove(selectedList, removedItem) {
 | `loading` | `bool` | `false` | If options is fetching from api, in the meantime, we can show `loading...` message in the list.
 | `loadingMessage` | `any` | `''` | Custom loading message, it can be string or component.
 | `showArrow` | `bool` | `false` | For multiselect dropdown by default arrow wont show at the end, If required based on flag we can display
+| `keepSearchTerm` | `bool` | `false` | Whether or not to keep the search value after selecting or removing an item
 ----
 
 

--- a/src/multiselect/multiselect.component.js
+++ b/src/multiselect/multiselect.component.js
@@ -22,6 +22,7 @@ export class Multiselect extends React.Component {
       toggleOptionsList: false,
       highlightOption: props.avoidHighlightFirstOption ? -1 : 0,
 			showCheckbox: props.showCheckbox,
+      keepSearchTerm: props.keepSearchTerm,
       groupedObject: [],
       closeIconType: closeIconTypes[props.closeIcon] || closeIconTypes['circle']
     };
@@ -255,9 +256,11 @@ export class Multiselect extends React.Component {
   onSelectItem(item) {
     const { selectedValues } = this.state;
     const { selectionLimit, onSelect, singleSelect, showCheckbox } = this.props;
-    this.setState({
-      inputValue: ''
-    });
+    if (!this.state.keepSearchTerm){
+      this.setState({
+        inputValue: ''
+      });
+    }
     if (singleSelect) {
       this.onSingleSelect(item);
       onSelect([item], item);


### PR DESCRIPTION
This small change allows preserving the search value between selections and removals.
Previously the search term would be cleared upon selecting or removing an item.

Unclear if this behavior was intentional so added as prop for user to decide.