### PR TITLE
Provide disableFilter and customFilter options

### DIFF
--- a/src/multiselect/multiselect.component.tsx
+++ b/src/multiselect/multiselect.component.tsx
@@ -62,7 +62,7 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
     this.getSelectedItemsCount = this.getSelectedItemsCount.bind(this);
     this.hideOnClickOutside = this.hideOnClickOutside.bind(this);
     this.isVisible = this.isVisible.bind(this);
-    this.customFilter = props.customFilter.bind(this);
+    this.customFilter = props?.customFilter?.bind(this);
   }
 
   initialSetValue() {


### PR DESCRIPTION
It's required in our product to provide our own filter method (using a fuzzy match) or disable filtering completely in certain cases which are both currently unsupported.

Not 100% sure the provided PR will work, but if not, something similar would be greatly appreciated.