### PR TITLE
Bugfix for issues #147 and  #72

### DIFF
--- a/src/multiselect/multiselect.component.tsx
+++ b/src/multiselect/multiselect.component.tsx
@@ -537,6 +537,9 @@ export class Multiselect extends React.Component<IMultiselectProps, any> {
           className={`optionListContainer ${
             toggleOptionsList ? 'displayBlock' : 'displayNone'
           }`}
+          onMouseDown={(e) => {
+            e.preventDefault();
+          }}
         >
           {this.renderOptionList()}
         </div>


### PR DESCRIPTION
This PR fixes a bug when Multiselect-react-dropdown is used in a modal window (Issues #72 and #147).

**Replicating the bug (Firefox 94.0, Chrome 95.0):**
- place <Multiselect> inside a modal component of MUI (see below for specific cases)
- create options list that needs scrolling for the scrollbar to appear.
- try to scroll by clicking on the scrollbar
==> Multiselect closes

edit: the bug appears in this structure: 
```
<Modal>
    <Box>
        <Multiselect/>
    <Box>
<Modal>
```
but not in this structure:
```
 <Modal>
    <>
        <Multiselect/>
    </>
<Modal/>
```

**Why I think the bug occurs:**
- Multiselect uses onFocus/onBlur to hide/show the options list. However there is a strange browser behavior where clicking on scrollbar emits an onBlur event (see for example https://bugs.chromium.org/p/chromium/issues/detail?id=51469), thus closing the dropdown.  This is not exclusive to Multiselect.

**How I solve this in Multiselect:**
- inside element optionListContainer onMouseDown is defined and default action is prevented.

